### PR TITLE
mtr: Handle delayed ICMP and hop socket close (DEM-8249)

### DIFF
--- a/packet/probe.h
+++ b/packet/probe.h
@@ -110,6 +110,9 @@ struct probe_t {
 
     /*  Platform specific probe tracking  */
     struct probe_platform_t platform;
+
+    /* Save error code - waiting for ICMP which may never arrive, use this on timeout when the ICMP does not arrive */
+    int saved_icmp_error;
 };
 
 /*  Global state for interacting with the network  */


### PR DESCRIPTION
## Description

There were two issues in mtr:

* A race condition between receiving an ICMP (via a raw socket) or a socket close notification from the operating system for the TCP connect. The socket close connection doesn't provide the IP of the hop while the ICMP does. MTR was taking whichever one it got first. We have changed it to wait for the ICMP (or a timeout) even if it gets the socket close first.

* When mtr processed a socket close it assumed it was from the target host no matter what the connect error was. This was also now been changed to report a TTL expire with no IP for the case where the socket error indicates it was from an intermediate hop and not the report that it successfully connected to the destination host.

## How Has This Been Tested?

Both mtr-packet and mtr have been tested with a a gateway which drops or delays ICMP replies until after the socket close.

### mtr-packet

Given input:

```
% cat seqs
1 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62501 ttl 1
2 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62502 ttl 2
3 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62503 ttl 3
4 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62504 ttl 4
5 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62505 ttl 5
6 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62506 ttl 6
7 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62507 ttl 7
8 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62508 ttl 8
9 send-probe ip-4 10.6.16.29 protocol tcp port 80 local-port 62509 ttl 9
```

Before:

```
% cat seqs | sudo mtr-packet
3 reply ip-4 10.6.16.29 round-trip-time 238421 seq 62503
4 reply ip-4 10.6.16.29 round-trip-time 238452 seq 62504
5 reply ip-4 10.6.16.29 round-trip-time 242507 seq 62505
6 reply ip-4 10.6.16.29 round-trip-time 242531 seq 62506
9 reply ip-4 10.6.16.29 round-trip-time 242337 seq 62509
7 reply ip-4 10.6.16.29 round-trip-time 242524 seq 62507
8 reply ip-4 10.6.16.29 round-trip-time 242466 seq 62508
1 no-reply
2 no-reply
```

After:

```
% cat seqs | sudo mtr/mtr-packet
3 ttl-expired ip-4 10.101.97.1 round-trip-time 238881 seq 62503 ds 0
4 ttl-expired ip-4 10.101.254.1 round-trip-time 238899 seq 62504 ds 0
5 ttl-expired ip-4 10.101.1.42 round-trip-time 238892 seq 62505 ds 0
9 reply ip-4 10.6.16.29 round-trip-time 240344 seq 62509
7 ttl-expired ip-4 10.55.1.18 round-trip-time 240670 seq 62507 ds 0
8 ttl-expired ip-4 10.5.1.5 round-trip-time 240726 seq 62508 ds 0
6 ttl-expired ip-4 10.55.1.2 round-trip-time 240877 seq 62506 ds 0
1 no-reply
2 no-reply
```

### MTR

Before

```
% sudo mtr --report-wide --timeout 15 -c 5 --max-ttl 30 --interval 1 --show-ips --mpls --rtt-clamping --end-verification -4 --tcp --port 80 10.6.16.29
Start: 2024-09-04T16:10:58-0700
HOST: mcurtiss-Virtual-Machine.local Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- ???                            100.0     5    0.0   0.0   0.0   0.0   0.0
  2.|-- ???                            100.0     5    0.0   0.0   0.0   0.0   0.0
  3.|-- 10.6.16.29                      0.0%     5  244.4 242.2 238.8 244.4   2.4
mcurtis@mcurtiss-Virtual-Machine ~ % sudo traceroute -P TCP -p 80 10.6.16.29          
```

```
% MTR_PACKET=$(pwd)/mtr/mtr-packet sudo mtr/mtr --report-wide --timeout 15 -c 5 --max-ttl 30 --interval 1 --show-ips --mpls --rtt-clamping --end-verification -4 --tcp --port 80 10.6.16.29
Start: 2024-09-04T16:13:46-0700
HOST: mcurtiss-Virtual-Machine.local Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- ???                            100.0     5    0.0   0.0   0.0   0.0   0.0
  2.|-- ???                            100.0     5    0.0   0.0   0.0   0.0   0.0
  3.|-- 10.101.97.1                    40.0%     5  3250. 3289. 3250. 3366.  66.6
  4.|-- 10.101.254.1                   40.0%     5  3366. 1953. 1246. 3366. 1224.0
  5.|-- 10.101.1.42                    20.0%     5  3248. 1246. 243.5 3248. 1414.6
  6.|-- 10.55.1.2                      60.0%     5  3366. 3366. 3366. 3366.   0.0
  7.|-- 10.55.1.18                     40.0%     5  3366. 3328. 3252. 3366.  65.9
  8.|-- 10.5.1.5                       20.0%     5  254.3 1751. 254.3 3254. 1291.3
  9.|-- 10.6.16.29                      0.0%     5  3366. 2520. 1247. 3366. 1158.6 
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
- [x] ^ but the same tests which failed before the patch also failed after the patch, and there are no new test failures
