### PR TITLE
add --trace-mtr-packet option to peek under the hood

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -110,6 +110,9 @@ mtr \- a network diagnostic tool
 .BI \-Z \ TIMEOUT\c
 ]
 [\c
+.B \-\-trace\-mtr\-packet\c
+]
+[\c
 .BI \-M \ MARK\c
 ]
 .I HOSTNAME
@@ -433,6 +436,9 @@ netfilter MARK target but socket-based.
 is 32 unsigned integer.  See
 .BR socket (7)
 for full description of this socket option.
+.TP
+.B \fB\-\-trace\-mtr\-packet
+Trace mtr-packet commands and responses to stderr.
 .SH ENVIRONMENT
 .B mtr
 recognizes a few environment variables.

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -489,6 +489,11 @@ void send_probe_command(
         error(EXIT_FAILURE, errno,
               "mtr-packet command pipe write failure");
     }
+
+    if (ctl->trace_mtr_packet) {
+        fputc('>', stderr);
+        fputs(command, stderr);
+    }
 }
 
 
@@ -693,6 +698,12 @@ void handle_command_reply(
     char *reply_name;
     struct mplslen mpls;
     int ds = -1; // -1 == could not determine DF (IPv4 TOS/IPv6 Traffic Class)
+
+    if (ctl->trace_mtr_packet) {
+        fputc('<', stderr);
+        fputs(reply_str, stderr);
+        fputc('\n', stderr);
+    }
 
     /*  Parse the reply string  */
     if (parse_command(&reply, reply_str)) {

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -182,6 +182,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
     fputs(" -A, --localport-max PORT   set the maximum local port to cycle through ports from local-port to this\n", out);
     fputs(" -q, --seqno NUMBER         set the initial sequence number\n", out);
     fputs(" -Y, --bind-interface IFNAME Bind the outgoing socket to the specified interface\n", out);
+    fputs("     --trace-mtr-packet     print mtr-packet i/o to stderr", out);
     fputs(" -h, --help                 display this help and exit\n", out);
     fputs
         (" -v, --version              output version information and exit\n",
@@ -335,7 +336,8 @@ static void parse_arg(
     enum {
         OPT_DISPLAYMODE = CHAR_MAX + 1,
         OPT_NO_PRIVATE_DNS = CHAR_MAX + 2,
-        OPT_NO_PUBLIC_DNS = CHAR_MAX + 3
+        OPT_NO_PUBLIC_DNS = CHAR_MAX + 3,
+        OPT_TRACE_MTR_PACKET = CHAR_MAX + 4
     };
     static const struct option long_options[] = {
         /* option name, has argument, NULL, short name */
@@ -403,6 +405,7 @@ static void parse_arg(
 #ifdef SO_MARK
         {"mark", 1, NULL, 'M'}, /* use SO_MARK */
 #endif
+        {"trace-mtr-packet", 0, NULL, OPT_TRACE_MTR_PACKET},
         {NULL, 0, NULL, 0}
     };
     enum { num_options = sizeof(long_options) / sizeof(struct option) };
@@ -449,6 +452,7 @@ static void parse_arg(
             printf("no-dns\n");                 ///< Supports --no-dns
             printf("no-private-dns\n");         ///< Supports --no-private-dns
             printf("no-public-dns\n");          ///< Supports --no-public-dns
+            printf("trace-mtr-packet\n");       ///< Supports --trace-mtr-packet
             exit(EXIT_SUCCESS);
             break;
 
@@ -708,6 +712,9 @@ static void parse_arg(
                 strtonum_or_err(optarg, "invalid argument", STRTO_U32INT);
             break;
 #endif
+        case OPT_TRACE_MTR_PACKET:
+            ctl->trace_mtr_packet = 1;
+            break;
         default:
             usage(stderr);
         }
@@ -859,6 +866,7 @@ int main(
     ctl.ipinfo_no = -1;
     ctl.ipinfo_max = -1;
     ctl.initial_seqno_offset = -1; /* random */
+    ctl.trace_mtr_packet = 0;
     xstrncpy(ctl.fld_active, "LS NABWV", 2 * MAXFLD);
 
     /*

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -118,7 +118,8 @@ struct mtr_ctl {
         use_dns:1,
         show_ips:1,
         enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5,
-        rttClamping:1, endVerification:1, private_dns:1, public_dns:1;
+        rttClamping:1, endVerification:1, private_dns:1, public_dns:1,
+        trace_mtr_packet:1;
 };
 
 /* dynamic field drawing */


### PR DESCRIPTION
`--trace-mtr-packet` duplicates mtr<->mtr-packet commands and replies to stderr